### PR TITLE
refactor: 차트표시 이탤릭 수정 넘버 리스트 보기 수정

### DIFF
--- a/reflective-client/src/components/PostView.tsx
+++ b/reflective-client/src/components/PostView.tsx
@@ -18,6 +18,8 @@ import useDeleteFavoriteMutation from "../hooks/api/useDeleteFavoriteMutation";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { USER_ID_KEY } from "../constants/api";
+import { Line } from "react-chartjs-2";
+import { ChartData } from "chart.js";
 
 interface Block {
   id: string;
@@ -29,7 +31,8 @@ interface Block {
     | "list"
     | "numbered-list"
     | "image"
-    | "code";
+    | "code"
+    | "chart";
   content: string;
 }
 
@@ -62,11 +65,23 @@ const BlockView: React.FC<{ block: Block }> = ({ block }) => {
     case "paragraph":
       return <div className="mb-4">{renderContent(block.content)}</div>;
     case "heading1":
-      return <h1 className="text-3xl font-bold mb-4">{block.content}</h1>;
+      return (
+        <h1 className="text-3xl font-bold mb-4">
+          {renderContent(block.content)}
+        </h1>
+      );
     case "heading2":
-      return <h2 className="text-2xl font-bold mb-4">{block.content}</h2>;
+      return (
+        <h2 className="text-2xl font-bold mb-4">
+          {renderContent(block.content)}
+        </h2>
+      );
     case "heading3":
-      return <h3 className="text-xl font-bold mb-4">{block.content}</h3>;
+      return (
+        <h3 className="text-xl font-bold mb-4">
+          {renderContent(block.content)}
+        </h3>
+      );
     case "list":
       return (
         <ul className="list-disc list-inside mb-4 pl-4">
@@ -90,7 +105,7 @@ const BlockView: React.FC<{ block: Block }> = ({ block }) => {
       );
     case "numbered-list":
       return (
-        <ol className="list-decimal list-inside mb-4 pl-4">
+        <ol className="list-inside mb-4 pl-4">
           {block.content.split("\n").map((item, index) => {
             const match = item.match(/^\s*/);
             const indent = match ? match[0].length : 0;
@@ -121,12 +136,33 @@ const BlockView: React.FC<{ block: Block }> = ({ block }) => {
           {block.content}
         </SyntaxHighlighter>
       );
+    case "chart": {
+      const chartData: ChartData<"line", (number | null)[], unknown> = (() => {
+        let parsedContent;
+
+        try {
+          // block.content를 JSON 객체로 파싱
+          parsedContent = JSON.parse(block.content);
+        } catch (error) {
+          console.error("JSON 파싱 오류:", error);
+          parsedContent = { labels: [], datasets: [] }; // 파싱 실패 시 기본값 설정
+        }
+
+        return {
+          labels: parsedContent.labels || [], // JSON에서 파싱한 labels
+          datasets: parsedContent.datasets || [], // JSON에서 파싱한 datasets
+        };
+      })();
+
+      return <Line data={chartData} />;
+    }
     default:
       return null;
   }
 };
 
 const PostView = (data: Partial<getPostType>) => {
+  console.log(data);
   const navigate = useNavigate();
   const user_id = localStorage.getItem(USER_ID_KEY);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/reflective-client/src/components/refactoringBlockEidtor/BlockRefectorEditor.tsx
+++ b/reflective-client/src/components/refactoringBlockEidtor/BlockRefectorEditor.tsx
@@ -131,9 +131,9 @@ const BlockEditor: React.FC<BlockEditorProps> = React.memo(
     const handleChartDataChange = useCallback(
       (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         try {
-          const newData = JSON.parse(e.target.value);
+          const newData = JSON.parse(e.target.value.trim());
           setChartData(newData);
-          updateBlock(block.id, JSON.stringify(newData), block.type);
+          updateBlock(block.id, e.target.value.trim(), block.type);
         } catch (error) {
           console.error("Invalid JSON:", error);
         }


### PR DESCRIPTION
## PR 설명
변경 사항에 대해 자세히 설명해주세요. 무엇이 변경되었는지, 왜 이러한 변경이 필요한지 설명합니다.

## 현재 동작
현재 애플리케이션에서는 포스트 보기 페이지에서 사용자가 작성한 차트, 이탤릭체, 목록 기능이 정확하게 표시되지 않거나 일부 스타일이 적용되지 않는 문제가 발생하고 있습니다.

## 새로운 동작
변경 후, 포스트 보기 페이지에서는 사용자가 작성한 차트, 이탤릭체, 목록 기능이 정확하게 렌더링되어 표시됩니다. 사용자 작성 스타일이 작성 페이지와 일관되게 유지됩니다.

## 변경 이유
이 변경은 포스트의 스타일이 제대로 렌더링되지 않는 문제를 해결하고, 작성된 포스트가 예상대로 시각적으로 정확하게 표시되도록 하기 위해 필요합니다.

## 이슈

 
## 기능 설명
포스트 보기 페이지에서 사용자가 작성한 포스트의 차트, 이탤릭체, 목록 기능이 제대로 표시되도록 수정. 
이를 통해 포스트의 다양한 스타일이 보기 페이지에서도 원활하게 표시

## 기대 효과
가독성 향상: 차트, 이탤릭체, 목록 기능이 정확히 렌더링되어 사용자들이 내용을 직관적으로 이해
일관된 사용자 경험 제공: 작성 페이지에서 설정한 스타일과 포스트 보기 페이지에서의 렌더링이 일치하여, 사용자 경험의 일관성을 높임
다양한 콘텐츠 표현 가능: 차트와 다양한 텍스트 스타일을 적용할 수 있어 포스트의 정보 전달력을 극대화


## 추가 정보

기타 참고할 사항이 있다면 작성해주세요.


#5 