### PR TITLE
리스트 컴포넌트 리스트 유효성 검사 테스트

### DIFF
--- a/apps/web/jest.setup.ts
+++ b/apps/web/jest.setup.ts
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom";
+Object.defineProperty(global, "crypto", {
+  value: {
+    randomUUID: () => "test-uuid",
+  },
+});

--- a/apps/web/src/features/Write/__tests__/ListEditor/ListEditor.test.tsx
+++ b/apps/web/src/features/Write/__tests__/ListEditor/ListEditor.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ListEditor from "../../ui/BlockEditor/ListEditor/ListEditor";
+import { Block } from "@/entities/BlockEditor/model/type/BlockEditor";
+import userEvent from "@testing-library/user-event";
+describe("ListEditor", () => {
+  const mockUpdateBlockContent = jest.fn();
+  const mockOnError = jest.fn();
+  const mockDebouncedUpdateRef = { current: jest.fn() };
+
+  const defaultProps = {
+    block: { id: "tests-block", type: "list" as Block["type"], content: "" },
+    blockContent: new Map<string, string>(),
+    updateBlockContent: mockUpdateBlockContent,
+    debouncedUpdateRef: mockDebouncedUpdateRef,
+    onError: mockOnError,
+  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('빈 리스트에 "리스트 아이템..." 인풋이 표시되어야 함', () => {
+    render(<ListEditor {...defaultProps} />);
+    expect(screen.getByPlaceholderText("리스트 아이템...")).toBeInTheDocument();
+  });
+
+  it("기본 리스트 아이템이 추가 되어야 함", () => {
+    render(<ListEditor {...defaultProps} />);
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getByRole("listitem")).toBeInTheDocument();
+  });
+
+  it("ListItem 컨텐츠 변경 시 handleListItemChange가 호출되어야 함", async () => {
+    render(<ListEditor {...defaultProps} />);
+    const input = screen.getByPlaceholderText("리스트 아이템...");
+    await userEvent.type(input, "test content");
+    expect(mockUpdateBlockContent).toHaveBeenCalled();
+  });
+
+  it("키보드 이벤트가 올바르게 처리되어야 함", async () => {
+    render(<ListEditor {...defaultProps} />);
+    const input = screen.getByPlaceholderText("리스트 아이템...");
+
+    await userEvent.type(input, "test");
+    input.focus();
+    await userEvent.keyboard("{enter}");
+
+    expect(mockUpdateBlockContent).toHaveBeenCalled();
+  });
+
+  it("Tab 키로 들여쓰기가 되어야 함", async () => {
+    render(<ListEditor {...defaultProps} />);
+    const input = screen.getByPlaceholderText("리스트 아이템...");
+
+    await userEvent.type(input, "test");
+    input.focus();
+    await userEvent.keyboard("{Tab}");
+
+    expect(mockUpdateBlockContent).toHaveBeenCalled();
+  });
+
+  it("Shift+Tab 키로 내어쓰기가 되어야 함", async () => {
+    render(<ListEditor {...defaultProps} />);
+    const input = screen.getByPlaceholderText("리스트 아이템...");
+
+    await userEvent.type(input, "test");
+    await userEvent.keyboard("{Tab}");
+    input.focus();
+    await userEvent.keyboard("{Shift>}{Tab}{/Shift}");
+
+    expect(mockUpdateBlockContent).toHaveBeenCalled();
+  });
+
+  it("스크롤 시 virtualItems가 업데이트되어야 함", async () => {
+    render(<ListEditor {...defaultProps} />);
+    const list = screen.getByRole("list");
+    fireEvent.scroll(list, { target: { scrollTop: 100 } });
+    expect(list).toHaveStyle({ height: "100%" });
+  });
+});

--- a/apps/web/src/features/Write/__tests__/ListEditor/ListItem.test.tsx
+++ b/apps/web/src/features/Write/__tests__/ListEditor/ListItem.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ListItem } from "../../ui/BlockEditor/ListEditor/ListItem";
+import userEvent from "@testing-library/user-event";
+
+describe("ListItem", () => {
+  const mockOnChange = jest.fn();
+  const mockOnKeyDown = jest.fn();
+  const defaultProps = {
+    item: {
+      id: "test-item",
+      content: "Test content",
+      level: 0,
+      isCollapsed: false,
+    },
+    number: "1.",
+    onChange: mockOnChange,
+    onKeyDown: mockOnKeyDown,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("아이템 정보가 올바르게 렌더링되어야 함", () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByDisplayValue("Test content");
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText("1.")).toBeInTheDocument();
+  });
+
+  it("들여쓰기 레벨에 따라 올바른 마진이 적용되어야 함", () => {
+    const props = {
+      ...defaultProps,
+      item: { ...defaultProps.item, level: 2 },
+    };
+    const { container } = render(<ListItem {...props} />);
+    const itemDiv = container.firstChild as HTMLElement;
+    expect(itemDiv).toHaveStyle({ marginLeft: "48px" });
+  });
+
+  it("입력값 변경 시 onChange가 호출되어야 함", async () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByDisplayValue("Test content") as HTMLInputElement;
+
+    await userEvent.clear(input);
+
+    fireEvent.change(input, { target: { value: "Test contentnew" } });
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith("test-item", "Test contentnew");
+    });
+  });
+
+  it("키 입력시 onKeyDown이 호출되어야 함", async () => {
+    render(<ListItem {...defaultProps} />);
+
+    const input = screen.getByDisplayValue("Test content");
+    input.focus();
+    await userEvent.keyboard("{enter}");
+    expect(mockOnKeyDown).toHaveBeenCalled();
+  });
+
+  it("placeholder 텍스트가 올바르게 표시되어야 함", () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByPlaceholderText("리스트 아이템...");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("입력 필드가 적절한 ARIA 레이블을 가져야 함", () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByLabelText("List item level 1");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("입력 필드의 스타일이 올바르게 적용되어야 함", () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByDisplayValue("Test content");
+    expect(input).toHaveClass(
+      "flex-1",
+      "px-2",
+      "py-1",
+      "bg-transparent",
+      "outline-none",
+      "border-none"
+    );
+  });
+
+  it("번호가 올바른 스타일로 렌더링되어야 함", () => {
+    render(<ListItem {...defaultProps} />);
+    const number = screen.getByText("1.");
+    expect(number).toHaveClass(
+      "mr-2",
+      "text-gray-500",
+      "min-w-[24px]",
+      "select-none"
+    );
+  });
+
+  it("ChevronDown 아이콘이 올바른 스타일로 렌더링되어야 함", () => {
+    const { container } = render(<ListItem {...defaultProps} />);
+    const chevronIcon = container.querySelector(".w-4.h-4.text-gray-400");
+    expect(chevronIcon).toBeInTheDocument();
+  });
+
+  it("inputRef가 전달되면 올바르게 적용되어야 함", () => {
+    const ref = jest.fn();
+    render(<ListItem {...defaultProps} inputRef={ref} />);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
+  });
+
+  it("빈 content로 렌더링되어도 정상적으로 동작해야 함", () => {
+    const emptyProps = {
+      ...defaultProps,
+      item: { ...defaultProps.item, content: "" },
+    };
+    render(<ListItem {...emptyProps} />);
+    const input = screen.getByPlaceholderText("리스트 아이템...");
+    expect(input).toHaveValue("");
+  });
+
+  it("여러 번의 입력 변경을 올바르게 처리해야 함", async () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByDisplayValue("Test content");
+
+    await userEvent.clear(input);
+
+    fireEvent.change(input, { target: { value: "First change" } });
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith("test-item", "First change");
+    });
+    await userEvent.clear(input);
+
+    fireEvent.change(input, { target: { value: "Second change" } });
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith("test-item", "Second change");
+    });
+  });
+
+  it("다양한 키보드 이벤트를 올바르게 처리해야 함", async () => {
+    render(<ListItem {...defaultProps} />);
+    const input = screen.getByDisplayValue("Test content");
+
+    await userEvent.type(input, "{enter}");
+    expect(mockOnKeyDown).toHaveBeenCalledWith(expect.any(Object), "test-item");
+
+    await userEvent.type(input, "{tab}");
+    expect(mockOnKeyDown).toHaveBeenCalledWith(expect.any(Object), "test-item");
+
+    await userEvent.type(input, "{backspace}");
+    expect(mockOnKeyDown).toHaveBeenCalledWith(expect.any(Object), "test-item");
+  });
+});

--- a/apps/web/src/features/Write/__tests__/ListEditor/Service/FocusManager.test.ts
+++ b/apps/web/src/features/Write/__tests__/ListEditor/Service/FocusManager.test.ts
@@ -1,0 +1,70 @@
+import { FocusManager } from "@/features/Write/libs/vallidation/list/focus";
+
+describe("FocusManager", () => {
+  let focusManager: FocusManager;
+  let refs: { current: Record<string, HTMLInputElement> };
+
+  beforeEach(() => {
+    // HTMLInputElement mock 생성
+    const mockInput = Object.assign(document.createElement("input"), {
+      focus: jest.fn(),
+      value: "test value",
+      selectionStart: 0,
+    });
+
+    refs = {
+      current: {
+        "item-1": mockInput,
+        "item-2": mockInput,
+        "item-3": mockInput,
+      },
+    };
+
+    focusManager = new FocusManager(refs);
+
+    // requestAnimationFrame 목
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("focus", () => {
+    it("유효한 id로 focus 호출 시 해당 요소에 포커스되어야 함", () => {
+      focusManager.focus("item-1");
+      expect(refs.current["item-1"].focus).toHaveBeenCalled();
+    });
+
+    it("빈 id로 focus 호출 시 아무 동작도 하지 않아야 함", () => {
+      focusManager.focus("");
+      expect(refs.current["item-1"].focus).not.toHaveBeenCalled();
+    });
+
+    it("focus 시 커거사 텍스트 끝으로 이동해야 함", () => {
+      focusManager.focus("item-1");
+      expect(refs.current["item-1"].selectionStart).toBe(
+        refs.current["item-1"].value.length
+      );
+    });
+  });
+  describe("focusPrevious", () => {
+    const items = [
+      { id: "item-1", content: "Item 1", level: 0, isCollapsed: false },
+      { id: "item-2", content: "Item 2", level: 0, isCollapsed: false },
+      { id: "item-3", content: "Item 3", level: 0, isCollapsed: false },
+    ];
+    it("이전 아이템으로 포커스가 이동해야 함", () => {
+      focusManager.focusPrevious("item-2", items);
+      expect(refs.current["item-1"].focus).toHaveBeenCalled();
+    });
+
+    it("첫 번째 아이템에서는 이전 포커스 이동이 발생하지 않아야 함", () => {
+      focusManager.focusPrevious("item-1", items);
+      expect(refs.current["item-1"].focus).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/features/Write/__tests__/ListEditor/Service/ListNumberingStrategy.test.ts
+++ b/apps/web/src/features/Write/__tests__/ListEditor/Service/ListNumberingStrategy.test.ts
@@ -1,0 +1,47 @@
+import { ListNumberingStrategy } from "@/features/Write/libs/vallidation/list/numbering";
+import { EDITOR_CONFIG } from "@/shared/constants/blockEditor";
+
+describe("ListNumberingStrategy", () => {
+  describe("bullet 타입", () => {
+    const strategy = new ListNumberingStrategy("bullet");
+
+    it("bullet 타입은 항상 기본 마커를 반환해야 함", () => {
+      const items = [
+        { id: "1", content: "Item 1", level: 0, isCollapsed: false },
+        { id: "2", content: "Item 2", level: 1, isCollapsed: false },
+      ];
+      expect(strategy.getMarker(items, 0)).toBe(
+        EDITOR_CONFIG.DEFAULT_WRITE_LIST_MARKER
+      );
+      expect(strategy.getMarker(items, 1)).toBe(
+        EDITOR_CONFIG.DEFAULT_WRITE_LIST_MARKER
+      );
+    });
+  });
+
+  describe("numbered타입", () => {
+    const strategy = new ListNumberingStrategy("numbered");
+
+    it("같은 레벨의 아이템은 순차적으로 번호가 매겨져야 함", () => {
+      const items = [
+        { id: "1", content: "Item 1", level: 0, isCollapsed: false },
+        { id: "2", content: "Item 2", level: 0, isCollapsed: false },
+      ];
+
+      expect(strategy.getMarker(items, 0)).toBe("1.");
+      expect(strategy.getMarker(items, 1)).toBe("2.");
+    });
+
+    it("다른 레벨의 아이템은 다른 스타일로 표시되어야 함", () => {
+      const items = [
+        { id: "1", content: "Item 1", level: 0, isCollapsed: false },
+        { id: "2", content: "Item 2", level: 1, isCollapsed: false },
+        { id: "3", content: "Item 3", level: 2, isCollapsed: false },
+      ];
+
+      expect(strategy.getMarker(items, 0)).toBe("1.");
+      expect(strategy.getMarker(items, 1)).toBe("a.");
+      expect(strategy.getMarker(items, 2)).toBe("1)");
+    });
+  });
+});

--- a/apps/web/src/features/Write/__tests__/ListEditor/Service/ListValidator.test.ts
+++ b/apps/web/src/features/Write/__tests__/ListEditor/Service/ListValidator.test.ts
@@ -1,0 +1,88 @@
+import { ListValidator } from "@/features/Write/libs/vallidation/list/validation";
+
+describe("ListValidator", () => {
+  const options = {
+    maxLevel: 5,
+    minItems: 1,
+    maxItems: 5,
+    allowCollapse: true,
+  };
+
+  const validator = new ListValidator(options);
+
+  describe("validateItem", () => {
+    it("유효한 아이템은 에러를 발생시키지 않아야 함", () => {
+      const item = {
+        id: "1",
+        content: "Valid item",
+        level: 1,
+        isCollapsed: false,
+      };
+      expect(() => validator.validateItem(item)).not.toThrow();
+    });
+
+    it("최대 레벨을 초과하면 에러를 발생시켜야 함", () => {
+      const item = {
+        id: "1",
+        content: "Invalid level",
+        level: 6,
+        isCollapsed: false,
+      };
+      expect(() => validator.validateItem(item)).toThrow(
+        "유효하지 않는 들여쓰기 레벨: 6"
+      );
+    });
+
+    it("음수 레벨은 에러를 발생시켜야 함", () => {
+      const item = {
+        id: "1",
+        content: "Negative level",
+        level: -1,
+        isCollapsed: false,
+      };
+      expect(() => validator.validateItem(item)).toThrow(
+        "유효하지 않는 들여쓰기 레벨: -1"
+      );
+    });
+  });
+
+  describe("validateItems", () => {
+    it("유효한 아이템 목록은 에러를 발생시키지 않아야 함", () => {
+      const items = [
+        { id: "1", content: "Item 1", level: 0, isCollapsed: false },
+        { id: "2", content: "Item 2", level: 1, isCollapsed: false },
+      ];
+      expect(() => validator.validateItems(items)).not.toThrow();
+    });
+
+    it("최대 아이템 수를 초과하려면 에러를 발생시켜야 함", () => {
+      const items = [
+        { id: "1", content: "Item 1", level: 0, isCollapsed: false },
+        { id: "2", content: "Item 2", level: 1, isCollapsed: false },
+        { id: "3", content: "Item 3", level: 2, isCollapsed: false },
+        { id: "4", content: "Item 4", level: 3, isCollapsed: false },
+        { id: "5", content: "Item 5", level: 4, isCollapsed: false },
+        { id: "6", content: "Item 6", level: 5, isCollapsed: false },
+      ];
+      expect(() => validator.validateItems(items)).toThrow(
+        "아이템이 너무 많습니다: 6"
+      );
+    });
+
+    it("에러는 ListError 탑이이어야 함", () => {
+      const items = [
+        { id: "1", content: "Invalid level", level: 3, isCollapsed: false },
+      ];
+
+      try {
+        validator.validateItems(items);
+      } catch (error) {
+        expect(error).toMatchObject({
+          name: "ListError",
+          code: "VALIDATION_ERROR",
+          context: { options },
+        });
+      }
+    });
+  });
+});

--- a/apps/web/src/features/Write/__tests__/ListEditor/VirtualizedList.test.tsx
+++ b/apps/web/src/features/Write/__tests__/ListEditor/VirtualizedList.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from "@testing-library/react";
+import { VirtualizedList } from "../../ui/BlockEditor/ListEditor/VirtualizedList";
+
+describe("VirtualizedList", () => {
+  const mockOnScroll = jest.fn();
+  const mockRenderItem = jest.fn((index) => <div>{index}</div>);
+
+  const defaultProps = {
+    items: Array(200)
+      .fill(null)
+      .map((_, i) => ({
+        id: `item-${i}`,
+        content: `Item ${i}`,
+        level: 0,
+        isCollapsed: false,
+      })),
+    virtualItems: [
+      { index: 0, offsetTop: 0 },
+      { index: 1, offsetTop: 40 },
+      { index: 2, offsetTop: 80 },
+    ],
+    totalSize: 4000,
+    itemHeight: 40,
+    renderItem: mockRenderItem,
+    onScroll: mockOnScroll,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("가상 아이템들이 올바른 위치에 렌더링되어야 함", () => {
+    const { container } = render(<VirtualizedList {...defaultProps} />);
+    const items = container.querySelectorAll('[role="listitem"]');
+
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveStyle({ transform: "translateY(0px)" });
+    expect(items[1]).toHaveStyle({ transform: "translateY(40px)" });
+    expect(items[2]).toHaveStyle({ transform: "translateY(80px)" });
+  });
+
+  it("스크롤 시 onScroll이 호출되어야 함", async () => {
+    const { container } = render(<VirtualizedList {...defaultProps} />);
+    const list = container.firstChild as HTMLElement;
+    fireEvent.scroll(list, { target: { scrollTop: 100 } });
+
+    expect(mockOnScroll).toHaveBeenCalledWith(100);
+  });
+
+  it("totalSize에 따라 올바른 높이가 설정되어야 함", () => {
+    const { container } = render(<VirtualizedList {...defaultProps} />);
+
+    const virtualContainer = container.querySelector('[style*="height"]');
+    expect(virtualContainer).toHaveStyle({ height: "100%" });
+  });
+});


### PR DESCRIPTION
## 📋 PR 개요
ListEditor, ListItem, VirtualizedList, FocusManager, ListNumberingStrategy 관련 테스트를 추가 및 보완하였습니다.

## ✅ 추가된 테스트 목록
### 1. ListEditor 테스트 (ListEditor.test.tsx)
 빈 리스트에 "리스트 아이템..." 인풋이 표시되어야 함
 기본 리스트 아이템이 추가되어야 함
 ListItem 컨텐츠 변경 시 handleListItemChange가 호출되어야 함
 키보드 이벤트가 올바르게 처리되어야 함 (Enter, Tab, Shift+Tab)
 Tab 키로 들여쓰기가 되어야 함
 Shift+Tab 키로 내어쓰기가 되어야 함
 스크롤 시 virtualItems가 업데이트되어야 함
### 2. ListItem 테스트 (ListItem.test.tsx)
 아이템 정보가 올바르게 렌더링되어야 함
 들여쓰기 레벨에 따라 올바른 마진이 적용되어야 함
 입력값 변경 시 onChange가 호출되어야 함
 키 입력 시 onKeyDown이 호출되어야 함
 placeholder 텍스트가 올바르게 표시되어야 함
 입력 필드가 적절한 ARIA-label을 가져야 함
 입력 필드의 스타일이 올바르게 적용되어야 함
 번호(number)가 올바른 스타일로 렌더링되어야 함
 ChevronDown 아이콘이 올바른 스타일로 렌더링되어야 함
 inputRef가 전달되면 올바르게 적용되어야 함
 빈 content로 렌더링되어도 정상적으로 동작해야 함
 여러 번의 입력 변경을 올바르게 처리해야 함
 다양한 키보드 이벤트를 올바르게 처리해야 함
### 3. VirtualizedList 테스트 (VirtualizedList.test.tsx)
 가상 아이템들이 올바른 위치에 렌더링되어야 함
 스크롤 시 onScroll이 호출되어야 함
 totalSize에 따라 올바른 높이가 설정되어야 함
### 4. FocusManager 테스트 (FocusManager.test.ts)
 유효한 id로 focus 호출 시 해당 요소에 포커스되어야 함
 빈 id로 focus 호출 시 아무 동작도 하지 않아야 함
 focus 시 커서가 텍스트 끝으로 이동해야 함
 이전 아이템으로 포커스가 이동해야 함 (focusPrevious)
 첫 번째 아이템에서는 이전 포커스 이동이 발생하지 않아야 함
### 5. ListNumberingStrategy 테스트 (ListNumberingStrategy.test.ts)
 bullet 타입은 항상 기본 마커를 반환해야 함
 numbered 타입에서 같은 레벨의 아이템은 순차적으로 번호가 매겨져야 함
 numbered 타입에서 다른 레벨의 아이템은 다른 스타일로 표시되어야 함
### 🔧 변경 사항
ListEditor 및 ListItem에서 발생할 수 있는 입력 이벤트 및 키보드 이벤트 버그 검출을 위해 테스트 추가
가상 리스트 (VirtualizedList)에서 스크롤 이벤트 핸들링이 정상적으로 동작하는지 확인하는 테스트 추가
FocusManager 및 ListNumberingStrategy 관련 동작 검증 테스트 추가
### 🚀 테스트 결과
✅ 모든 테스트 케이스가 정상적으로 통과하였습니다. (PASS ✅)

